### PR TITLE
Installer enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
-MoneyMan
-========
+# MoneyMan
 
 A financial money management library and applications that utilize it.
 
-[![Install](https://img.shields.io/badge/Prerelease-win--x64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-x64/Nerdbank.MoneyMan.Setup.exe)
-[![Install](https://img.shields.io/badge/Prerelease-win--arm64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-arm64/Nerdbank.MoneyMan.Setup.exe)
+[![Install](https://img.shields.io/badge/prerelease-win--x64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-x64/Nerdbank.MoneyMan.Setup.exe)
+[![Install](https://img.shields.io/badge/prerelease-win--arm64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-arm64/Nerdbank.MoneyMan.Setup.exe)
 
 [![Join the chat at https://gitter.im/MoneyManagement/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MoneyManagement/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
 
@@ -12,6 +11,7 @@ A financial money management library and applications that utilize it.
 [![codecov](https://codecov.io/gh/aarnott/moneyman/branch/main/graph/badge.svg)](https://codecov.io/gh/aarnott/moneyman)
 
 ## Why?
+
 Because Intuit Quicken has become far too old to work well on modern systems. It suffers from:
 
 1. Poor support for high DPI screens

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@ MoneyMan
 
 A financial money management library and applications that utilize it.
 
+[![Install](https://img.shields.io/badge/Prerelease-win--x64-green)](https://moneyman-releases.s3.us-west-1.amazonaws.com/prerelease/win-x64/Nerdbank.MoneyMan.Setup.exe)
+[![Install](https://img.shields.io/badge/Prerelease-win--arm64-green)](https://moneyman-releases.s3.us-west-1.amazonaws.com/prerelease/win-arm64/Nerdbank.MoneyMan.Setup.exe)
+
+[![Join the chat at https://gitter.im/MoneyManagement/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MoneyManagement/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
+
 [![Azure Pipelines status](https://dev.azure.com/andrewarnott/OSS/_apis/build/status/AArnott.MoneyMan?branchName=main)](https://dev.azure.com/andrewarnott/OSS/_build/latest?definitionId=29&branchName=main)
 [![codecov](https://codecov.io/gh/aarnott/moneyman/branch/main/graph/badge.svg)](https://codecov.io/gh/aarnott/moneyman)
-
-[![Install](https://img.shields.io/badge/Install-win--x64-green)](https://github.com/aarnott/moneyman/releases/latest)
-[![Join the chat at https://gitter.im/MoneyManagement/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MoneyManagement/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
 
 ## Why?
 Because Intuit Quicken has become far too old to work well on modern systems. It suffers from:

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@ MoneyMan
 
 A financial money management library and applications that utilize it.
 
-[![Install](https://img.shields.io/badge/Prerelease-win--x64-green)](https://moneyman-releases.s3.us-west-1.amazonaws.com/prerelease/win-x64/Nerdbank.MoneyMan.Setup.exe)
-[![Install](https://img.shields.io/badge/Prerelease-win--arm64-green)](https://moneyman-releases.s3.us-west-1.amazonaws.com/prerelease/win-arm64/Nerdbank.MoneyMan.Setup.exe)
+[![Install](https://img.shields.io/badge/Prerelease-win--x64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-x64/Nerdbank.MoneyMan.Setup.exe)
+[![Install](https://img.shields.io/badge/Prerelease-win--arm64-green)](https://moneymanreleases.blob.core.windows.net/releases/prerelease/win-arm64/Nerdbank.MoneyMan.Setup.exe)
 
 [![Join the chat at https://gitter.im/MoneyManagement/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/MoneyManagement/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
 

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -39,7 +39,7 @@ stages:
         nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel -PackageSaveMode nuspec -ExcludeVersion -NonInteractive -Verbosity Quiet
         $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows\tools"
         Write-Host Downloading release info
-        & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
+        & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneymanreleases.blob.core.windows.net/releases/$(channel)/$(RID)
         $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).$(NUGETPACKAGEVERSION).nupkg"
         Write-Host "Preparing $input for release"
         & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input
@@ -48,19 +48,16 @@ stages:
     - publish: $(Build.StagingDirectory)/s3
       artifact: squirrelInstaller
       displayName: Publishing installer as a pipeline artifact
-    - task: S3Upload@1
-      displayName: Uploading release to S3
+    - task: AzureFileCopy@4
+      displayName: Publishing release
       inputs:
-        awsCredentials: AWS OSS AZP user
-        regionName: us-west-1
-        bucketName: moneyman-releases
-        sourceFolder: $(Build.StagingDirectory)\s3
-        globExpressions: |
-          RELEASES
-          Nerdbank.MoneyMan.Setup.exe
-          Nerdbank.MoneyMan.$(RID)-$(NUGETPACKAGEVERSION)-*.nupkg
-        targetFolder: $(channel)/$(RID)/
-        filesAcl: public-read
+        SourcePath: $(Build.StagingDirectory)\s3
+        azureSubscription: Azure Free Trial(c5eda4ed-4681-4034-8835-65d67e7d4b7c)
+        Destination: AzureBlob
+        storage: moneymanreleases
+        ContainerName: releases
+        BlobPrefix: $(channel)/$(RID)/
+        AdditionalArgumentsForBlobCopy: '--overwrite false'
 
 - stage: GitHubRelease
   displayName: GitHub Release

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -25,7 +25,7 @@ stages:
     - download: CI
       artifact: deployables-Windows
       displayName: Download Squirrel input package
-      patterns: 'deployables-Windows/SquirrelInputs/$(RID)/**'
+      patterns: 'deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).*.nupkg'
     - task: NuGetToolInstaller@1
       displayName: Use NuGet 5.x
       inputs:
@@ -33,14 +33,18 @@ stages:
     - powershell: |
         nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel
         $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows.$(SquirrelVersion)\tools"
+        Write-Host Downloading release info
         & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
-        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/$(RID)/*.nupkg
+        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/*.nupkg
+        Write-Host "Preparing $input for release"
         & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input
         ren $(Build.StagingDirectory)\s3\Setup.exe $(Build.StagingDirectory)\s3\Nerdbank.MoneyMan.Setup.exe -Force
       displayName: squirrel --releasify
-    - publish:
+    - publish: $(Build.StagingDirectory)/s3
       artifact: squirrelInstaller
+      displayName: Publishing installer as a pipeline artifact
     - task: S3Upload@1
+      displayName: Uploading release to S3
       inputs:
         awsCredentials: AWS OSS AZP user
         regionName: us-west-1

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -16,10 +16,9 @@ stages:
   - job:
     pool: Hosted Windows 2019 with VS2019
     variables:
-      channel: prerelease
-      RID: win-x64
       SquirrelVersion: 2.0.2-netcore
     steps:
+    - checkout: none
     - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
       displayName: Set pipeline name
     - download: CI
@@ -27,37 +26,49 @@ stages:
       displayName: Download pipeline variables
     - powershell: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
       displayName: Applying pipeline variables
-    - download: CI
-      artifact: deployables-Windows
-      displayName: Download Squirrel input package
-      patterns: 'deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).$(NUGETPACKAGEVERSION).nupkg'
     - task: NuGetToolInstaller@1
       displayName: Use NuGet 5.x
       inputs:
         versionSpec: 5.x
+    - download: CI
+      artifact: deployables-Windows
+      displayName: Download Squirrel input packages
+      patterns: 'deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.*.$(NUGETPACKAGEVERSION).nupkg'
     - powershell: |
+        Write-Host "Installing Squirrel"
         nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel -PackageSaveMode nuspec -ExcludeVersion -NonInteractive -Verbosity Quiet
         $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows\tools"
-        Write-Host Downloading release info
-        & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneymanreleases.blob.core.windows.net/releases/$(channel)/$(RID)
-        $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).$(NUGETPACKAGEVERSION).nupkg"
-        Write-Host "Preparing $input for release"
-        & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input
-        ren $(Build.StagingDirectory)\s3\Setup.exe $(Build.StagingDirectory)\s3\Nerdbank.MoneyMan.Setup.exe -Force
+
+        if ("$(NUGETPACKAGEVERSION)".Contains('-')) {
+          $channel = "prerelease"
+        } else {
+          $channel = "release"
+        }
+
+        "win-x64","win-arm64" |% {
+          $localRidPath = "$(Build.StagingDirectory)\release_blobs\$channel\$_"
+          Write-Host "Downloading release info"
+          & "$SquirrelTools\SyncReleases" -r $localRidPath  -u https://moneymanreleases.blob.core.windows.net/releases/$channel/$_
+          $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$_.$(NUGETPACKAGEVERSION).nupkg"
+
+          Write-Host "Preparing $input for release"
+          & "$SquirrelTools\Squirrel" -r $localRidPath --no-msi --releasify $input
+          ren $localRidPath\Setup.exe $localRidPath\Nerdbank.MoneyMan.Setup.exe -Force
+        }
       displayName: squirrel --releasify
-    - publish: $(Build.StagingDirectory)/s3
+    - publish: $(Build.StagingDirectory)/release_blobs
       artifact: squirrelInstaller
       displayName: Publishing installer as a pipeline artifact
+
     - task: AzureFileCopy@4
       displayName: Publishing release
       inputs:
-        SourcePath: $(Build.StagingDirectory)\s3\*
+        SourcePath: $(Build.StagingDirectory)\release_blobs
         azureSubscription: Azure Free Trial(c5eda4ed-4681-4034-8835-65d67e7d4b7c)
         Destination: AzureBlob
         storage: moneymanreleases
         ContainerName: releases
-        BlobPrefix: $(channel)/$(RID)/
-        AdditionalArgumentsForBlobCopy: '--overwrite false'
+        AdditionalArgumentsForBlobCopy: '--overwrite false --recursive'
 
 - stage: GitHubRelease
   displayName: GitHub Release
@@ -70,6 +81,7 @@ stages:
       runOnce:
         deploy:
           steps:
+          - download: none
           - task: GitHubRelease@1
             displayName: GitHub release (create)
             inputs:

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -55,6 +55,11 @@ stages:
           $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$_.$(NUGETPACKAGEVERSION).nupkg"
           & "$SquirrelTools\Squirrel" -r $localRidPath --no-msi --releasify $input
           ren $localRidPath\Setup.exe $localRidPath\Nerdbank.MoneyMan.Setup.exe -Force
+
+          # We only want to upload files to blob storage that were not already there or that we intend to overwrite.
+          # We do this by deleting files that are not new from this pipeline.
+          # Note the -Exclude list are the files we KEEP and upload.
+          del $localRidPath\* -Exclude RELEASES,Nerdbank.MoneyMan.Setup.exe,Nerdbank.MoneyMan.$_-$(NUGETPACKAGEVERSION)-*.nupkg
         }
       displayName: Build squirrel packages
     - publish: $(Build.StagingDirectory)/release_blobs

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -18,7 +18,8 @@ stages:
     variables:
       SquirrelVersion: 2.0.2-netcore
     steps:
-    - checkout: none
+    - checkout: self # we need this for nuget.config so that `nuget install` will work
+      clean: true
     - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
       displayName: Set pipeline name
     - download: CI
@@ -47,7 +48,7 @@ stages:
 
         "win-x64","win-arm64" |% {
           $localRidPath = "$(Build.StagingDirectory)\release_blobs\$channel\$_"
-          Write-Host "Downloading release info"
+          Write-Host "Downloading release info for $_"
           & "$SquirrelTools\SyncReleases" -r $localRidPath  -u https://moneymanreleases.blob.core.windows.net/releases/$channel/$_
           $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$_.$(NUGETPACKAGEVERSION).nupkg"
 

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -56,7 +56,7 @@ stages:
           & "$SquirrelTools\Squirrel" -r $localRidPath --no-msi --releasify $input
           ren $localRidPath\Setup.exe $localRidPath\Nerdbank.MoneyMan.Setup.exe -Force
         }
-      displayName: squirrel --releasify
+      displayName: Build squirrel packages
     - publish: $(Build.StagingDirectory)/release_blobs
       artifact: squirrelInstaller
       displayName: Publishing installer as a pipeline artifact
@@ -64,7 +64,7 @@ stages:
     - task: AzureFileCopy@4
       displayName: Publishing release
       inputs:
-        SourcePath: $(Build.StagingDirectory)\release_blobs
+        SourcePath: $(Build.StagingDirectory)\release_blobs\*
         azureSubscription: Azure Free Trial(c5eda4ed-4681-4034-8835-65d67e7d4b7c)
         Destination: AzureBlob
         storage: moneymanreleases

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -14,6 +14,7 @@ stages:
   displayName: squirrel releasify
   jobs:
   - job:
+    pool: Hosted Windows 2019 with VS2019
     variables:
       channel: prerelease
       RID: win-x64

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -23,9 +23,9 @@ stages:
     - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
       displayName: Set pipeline name
     - download: CI
-      artifact: variables-Windows
+      artifact: Variables-Windows
       displayName: Download pipeline variables
-    - powershell: $(Pipeline.Workspace)/CI/variables-Windows/_pipelines.ps1
+    - powershell: $(Pipeline.Workspace)/CI/Variables-Windows/_pipelines.ps1
       displayName: Applying pipeline variables
     - download: CI
       artifact: deployables-Windows

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -10,6 +10,51 @@ resources:
       - auto-release
 
 stages:
+- stage: releasify
+  displayName: squirrel releasify
+  jobs:
+  - job:
+    variables:
+      platform: win-x64
+    steps:
+    - template: install-dependencies.yml
+    - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
+      displayName: Set pipeline name
+    - download: CI
+      artifact: deployables-Windows
+      displayName: Download Squirrel input package
+      patterns: 'deployables-Windows/SquirrelInputs/$(platform)/**'
+    - task: S3Download@1
+      displayName: Download releases from S3
+      inputs:
+        awsCredentials: AWS OSS AZP user
+        regionName: us-west-1
+        bucketName: moneyman-releases
+        sourceFolder: prerelease/$(platform)
+        globExpressions: |
+          RELEASES
+          *.nupkg
+        targetFolder: $(Build.StagingDirectory)\s3
+    - powershell: |
+        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/$(platform)/*.nupkg
+        squirrel --releaseDir="$(Build.StagingDirectory)\s3" --no-msi --releasify $input
+        ren $(Build.StagingDirectory)\s3\Setup.exe $(Build.StagingDirectory)\s3\Nerdbank.MoneyMan.Setup.exe -Force
+      displayName: squirrel --releasify
+    - publish:
+      artifact: squirrelInstaller
+    - task: S3Upload@1
+      inputs:
+        awsCredentials: AWS OSS AZP user
+        regionName: us-west-1
+        bucketName: moneyman-releases
+        sourceFolder: $(Build.StagingDirectory)\s3
+        globExpressions: |
+          RELEASES
+          *.exe
+          Nerdbank.MoneyMan.*-*.nupkg
+        targetFolder: prerelease/win-x64/
+        filesAcl: public-read
+
 - stage: GitHubRelease
   displayName: GitHub Release
   jobs:
@@ -21,14 +66,6 @@ stages:
       runOnce:
         deploy:
           steps:
-          - download: none
-          - powershell: |
-              Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
-            displayName: Set pipeline name
-          - download: CI
-            artifact: deployables-Windows
-            displayName: Download deployables-Windows artifact
-            patterns: 'deployables-Windows/Installers/win-x64/**'
           - task: GitHubRelease@1
             displayName: GitHub release (create)
             inputs:
@@ -38,7 +75,6 @@ stages:
               tagSource: userSpecifiedTag
               tag: v$(resources.pipeline.CI.runName)
               title: v$(resources.pipeline.CI.runName)
-              assets: $(Pipeline.Workspace)/CI/deployables-Windows/Installers/win-x64/** # Release assets have no folder, so we can't upload 2+ installer folders
               isDraft: true # After running this step, visit the new draft release, edit, and publish.
               changeLogCompareToRelease: lastNonDraftRelease
               changeLogType: issueBased

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -31,8 +31,8 @@ stages:
       inputs:
         versionSpec: 5.x
     - powershell: |
-        nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel
-        $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows.$(SquirrelVersion)\tools"
+        nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel -PackageSaveMode nuspec -ExcludeVersion -NonInteractive -Verbosity Quiet
+        $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows\tools"
         Write-Host Downloading release info
         & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
         $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/*.nupkg
@@ -52,7 +52,7 @@ stages:
         sourceFolder: $(Build.StagingDirectory)\s3
         globExpressions: |
           RELEASES
-          *.exe
+          Nerdbank.MoneyMan.Setup.exe
           Nerdbank.MoneyMan.*-*.nupkg
         targetFolder: $(channel)/$(RID)/
         filesAcl: public-read

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -32,7 +32,7 @@ stages:
         versionSpec: 5.x
     - powershell: |
         nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel
-        $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\tools"
+        $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows.$(SquirrelVersion)\tools"
         & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
         $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/$(RID)/*.nupkg
         & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -51,7 +51,7 @@ stages:
     - task: AzureFileCopy@4
       displayName: Publishing release
       inputs:
-        SourcePath: $(Build.StagingDirectory)\s3
+        SourcePath: $(Build.StagingDirectory)\s3\*
         azureSubscription: Azure Free Trial(c5eda4ed-4681-4034-8835-65d67e7d4b7c)
         Destination: AzureBlob
         storage: moneymanreleases

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -48,11 +48,11 @@ stages:
 
         "win-x64","win-arm64" |% {
           $localRidPath = "$(Build.StagingDirectory)\release_blobs\$channel\$_"
-          Write-Host "Downloading release info for $_"
+          Write-Host "Downloading prior release for $_"
           & "$SquirrelTools\SyncReleases" -r $localRidPath  -u https://moneymanreleases.blob.core.windows.net/releases/$channel/$_
-          $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$_.$(NUGETPACKAGEVERSION).nupkg"
 
-          Write-Host "Preparing $input for release"
+          Write-Host "Building new release package for $_"
+          $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$_.$(NUGETPACKAGEVERSION).nupkg"
           & "$SquirrelTools\Squirrel" -r $localRidPath --no-msi --releasify $input
           ren $localRidPath\Setup.exe $localRidPath\Nerdbank.MoneyMan.Setup.exe -Force
         }
@@ -69,7 +69,7 @@ stages:
         Destination: AzureBlob
         storage: moneymanreleases
         ContainerName: releases
-        AdditionalArgumentsForBlobCopy: '--overwrite false --recursive'
+        AdditionalArgumentsForBlobCopy: '--overwrite true --recursive'
 
 - stage: GitHubRelease
   displayName: GitHub Release

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -23,9 +23,14 @@ stages:
     - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
       displayName: Set pipeline name
     - download: CI
+      artifact: variables-Windows
+      displayName: Download pipeline variables
+    - powershell: $(Pipeline.Workspace)/CI/variables-Windows/_pipelines.ps1
+      displayName: Applying pipeline variables
+    - download: CI
       artifact: deployables-Windows
       displayName: Download Squirrel input package
-      patterns: 'deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).*.nupkg'
+      patterns: 'deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).$(NUGETPACKAGEVERSION).nupkg'
     - task: NuGetToolInstaller@1
       displayName: Use NuGet 5.x
       inputs:
@@ -35,7 +40,7 @@ stages:
         $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\squirrel.windows\tools"
         Write-Host Downloading release info
         & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
-        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/*.nupkg
+        $input = "$(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/Nerdbank.MoneyMan.$(RID).$(NUGETPACKAGEVERSION).nupkg"
         Write-Host "Preparing $input for release"
         & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input
         ren $(Build.StagingDirectory)\s3\Setup.exe $(Build.StagingDirectory)\s3\Nerdbank.MoneyMan.Setup.exe -Force
@@ -53,7 +58,7 @@ stages:
         globExpressions: |
           RELEASES
           Nerdbank.MoneyMan.Setup.exe
-          Nerdbank.MoneyMan.*-*.nupkg
+          Nerdbank.MoneyMan.$(RID)-$(NUGETPACKAGEVERSION)-*.nupkg
         targetFolder: $(channel)/$(RID)/
         filesAcl: public-read
 

--- a/azure-pipelines/release.yml
+++ b/azure-pipelines/release.yml
@@ -15,29 +15,26 @@ stages:
   jobs:
   - job:
     variables:
-      platform: win-x64
+      channel: prerelease
+      RID: win-x64
+      SquirrelVersion: 2.0.2-netcore
     steps:
-    - template: install-dependencies.yml
     - powershell: Write-Host "##vso[build.updatebuildnumber]$(resources.pipeline.CI.runName)"
       displayName: Set pipeline name
     - download: CI
       artifact: deployables-Windows
       displayName: Download Squirrel input package
-      patterns: 'deployables-Windows/SquirrelInputs/$(platform)/**'
-    - task: S3Download@1
-      displayName: Download releases from S3
+      patterns: 'deployables-Windows/SquirrelInputs/$(RID)/**'
+    - task: NuGetToolInstaller@1
+      displayName: Use NuGet 5.x
       inputs:
-        awsCredentials: AWS OSS AZP user
-        regionName: us-west-1
-        bucketName: moneyman-releases
-        sourceFolder: prerelease/$(platform)
-        globExpressions: |
-          RELEASES
-          *.nupkg
-        targetFolder: $(Build.StagingDirectory)\s3
+        versionSpec: 5.x
     - powershell: |
-        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/$(platform)/*.nupkg
-        squirrel --releaseDir="$(Build.StagingDirectory)\s3" --no-msi --releasify $input
+        nuget install Squirrel.Windows -Version $(SquirrelVersion) -OutputDirectory $(Agent.TempDirectory)\Squirrel
+        $SquirrelTools = "$(Agent.TempDirectory)\Squirrel\tools"
+        & "$SquirrelTools\SyncReleases" -r "$(Build.StagingDirectory)\s3"  -u https://moneyman-releases.s3.us-west-1.amazonaws.com/$(channel)/$(RID)
+        $input = Get-ChildItem $(Pipeline.Workspace)/CI/deployables-Windows/SquirrelInputs/$(RID)/*.nupkg
+        & "$SquirrelTools\Squirrel" -r "$(Build.StagingDirectory)\s3" --no-msi --releasify $input
         ren $(Build.StagingDirectory)\s3\Setup.exe $(Build.StagingDirectory)\s3\Nerdbank.MoneyMan.Setup.exe -Force
       displayName: squirrel --releasify
     - publish:
@@ -52,7 +49,7 @@ stages:
           RELEASES
           *.exe
           Nerdbank.MoneyMan.*-*.nupkg
-        targetFolder: prerelease/win-x64/
+        targetFolder: $(channel)/$(RID)/
         filesAcl: public-read
 
 - stage: GitHubRelease

--- a/azure-pipelines/variables/NuGetPackageVersion.ps1
+++ b/azure-pipelines/variables/NuGetPackageVersion.ps1
@@ -1,0 +1,2 @@
+# Just capture the value produced earlier in the pipeline.
+$env:NuGetPackageVersion

--- a/azure-pipelines/variables/NuGetPackageVersion.ps1
+++ b/azure-pipelines/variables/NuGetPackageVersion.ps1
@@ -1,2 +1,2 @@
 # Just capture the value produced earlier in the pipeline.
-$env:NuGetPackageVersion
+& (& "$PSScriptRoot\..\Get-nbgv.ps1") get-version -v NuGetPackageVersion

--- a/installers/MoneyMan.WPF.Installer/MoneyMan.WPF.Installer.msbuildproj
+++ b/installers/MoneyMan.WPF.Installer/MoneyMan.WPF.Installer.msbuildproj
@@ -12,9 +12,7 @@
 		<PackageType>Squirrel</PackageType>
 		<NoWarn>$(NoWarn);NU5128</NoWarn>
 		<GenerateNuspecDependsOn>$(GenerateNuspecDependsOn);GatherPayload</GenerateNuspecDependsOn>
-
-		<!-- Our primary output is actually just an intermediate step before we run "squirrel releasify". -->
-		<PackageOutputPath>$(BaseIntermediateOutputPath)$(Configuration)\</PackageOutputPath>
+		<PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\SquirrelInputs\</PackageOutputPath>
 	</PropertyGroup>
 	<ItemGroup>
 		<ProjectReference Include="$(RepoRootPath)src\MoneyMan.WPF\MoneyMan.WPF.csproj">
@@ -35,17 +33,5 @@
 				<PackagePath>lib\net45\%(RelativePath)</PackagePath>
 			</None>
 		</ItemGroup>
-	</Target>
-
-	<Target Name="Releasify" DependsOnTargets="Pack" AfterTargets="Pack">
-		<ItemGroup>
-			<IntermediatePackageOutput Include="@(NuGetPackOutput)" Condition=" %(Extension) == '.nupkg' " />
-		</ItemGroup>
-		<PropertyGroup>
-			<ReleaseDir>$(RepoRootPath)bin/Packages/$(Configuration)/Installers/$(RuntimeIdentifier)</ReleaseDir>
-		</PropertyGroup>
-		<Exec Command='"$(Pkgsquirrel_windows)\tools\Squirrel.exe" --releaseDir="$(ReleaseDir)" --no-msi --releasify "@(IntermediatePackageOutput)"' />
-		<Copy SourceFiles="$(ReleaseDir)/Setup.exe" DestinationFiles="$(ReleaseDir)/Nerdbank.MoneyMan.Setup.exe" OverwriteReadonlyFiles="true" SkipUnchangedFiles="true" />
-		<Delete Files="$(ReleaseDir)/Setup.exe" />
 	</Target>
 </Project>

--- a/installers/MoneyMan.WPF.Installer/MoneyMan.WPF.Installer.msbuildproj
+++ b/installers/MoneyMan.WPF.Installer/MoneyMan.WPF.Installer.msbuildproj
@@ -22,9 +22,6 @@
 			<Private>false</Private>
 		</ProjectReference>
 	</ItemGroup>
-	<ItemGroup>
-		<PackageReference Include="Squirrel.Windows" Version="2.0.2-netcore" NoWarn="NU1701" />
-	</ItemGroup>
 
 	<Target Name="GatherPayload" BeforeTargets="_GetPackageFiles" DependsOnTargets="ResolveProjectReferences">
 		<ItemGroup>

--- a/src/MoneyMan.WPF/App.xaml.cs
+++ b/src/MoneyMan.WPF/App.xaml.cs
@@ -54,7 +54,7 @@ namespace MoneyMan
 			};
 
 			return new UpdateManager(
-				  urlOrPath: $"https://moneyman-releases.s3.us-west-1.amazonaws.com/{channel}/{subchannel}/",
+				  urlOrPath: $"https://moneymanreleases.blob.core.windows.net/releases/{channel}/{subchannel}/",
 				  applicationName: "MoneyMan");
 		}
 	}

--- a/src/MoneyMan.WPF/App.xaml.cs
+++ b/src/MoneyMan.WPF/App.xaml.cs
@@ -6,6 +6,7 @@ namespace MoneyMan
 	using System;
 	using System.IO;
 	using System.Reflection;
+	using System.Runtime.InteropServices;
 	using System.Windows;
 	using Squirrel;
 
@@ -17,19 +18,19 @@ namespace MoneyMan
 		[STAThread]
 		public static void Main()
 		{
-			using (var mgr = new UpdateManager(null))
+			static void CreateShortcuts(UpdateManager mgr)
 			{
-				static void CreateShortcuts(UpdateManager mgr)
-				{
-					mgr.CreateShortcutsForExecutable(
-						Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly()!.Location) + ".exe",
-						ShortcutLocation.StartMenu | ShortcutLocation.Desktop,
-						updateOnly: !Environment.CommandLine.Contains("squirrel-install"),
-						programArguments: null,
-						icon: null);
-				}
+				mgr.CreateShortcutsForExecutable(
+					Path.GetFileNameWithoutExtension(Assembly.GetEntryAssembly()!.Location) + ".exe",
+					ShortcutLocation.StartMenu | ShortcutLocation.Desktop,
+					updateOnly: !Environment.CommandLine.Contains("squirrel-install"),
+					programArguments: null,
+					icon: null);
+			}
 
-				// Note, in most of these scenarios, the app exits after this method completes!
+			// Note, in most of these scenarios, the app exits after this method completes!
+			using (UpdateManager mgr = CreateUpdateManager())
+			{
 				SquirrelAwareApp.HandleEvents(
 				  onInitialInstall: v => CreateShortcuts(mgr),
 				  onAppUpdate: v => CreateShortcuts(mgr),
@@ -39,6 +40,22 @@ namespace MoneyMan
 			App app = new();
 			app.InitializeComponent();
 			app.Run();
+		}
+
+		internal static UpdateManager CreateUpdateManager()
+		{
+			string channel = ThisAssembly.IsPrerelease ? "prerelease" : "release";
+			string subchannel = RuntimeInformation.ProcessArchitecture switch
+			{
+				Architecture.Arm64 => "win-arm64",
+				Architecture.X64 => "win-x64",
+				Architecture.X86 => "win-x86",
+				_ => throw new NotSupportedException("Unrecognized process architecture."),
+			};
+
+			return new UpdateManager(
+				  urlOrPath: $"https://moneyman-releases.s3.us-west-1.amazonaws.com/{channel}/{subchannel}/",
+				  applicationName: "MoneyMan");
 		}
 	}
 }

--- a/src/MoneyMan.WPF/MainWindow.xaml.cs
+++ b/src/MoneyMan.WPF/MainWindow.xaml.cs
@@ -174,8 +174,8 @@ namespace MoneyMan
 				return;
 			}
 
-			using UpdateManager updateManager = await UpdateManager.GitHubUpdateManager("https://github.com/aarnott/moneyman", prerelease: ThisAssembly.IsPrerelease);
-			ReleaseEntry result = await updateManager.UpdateApp();
+			using UpdateManager updateManager = App.CreateUpdateManager();
+			ReleaseEntry result = await updateManager.UpdateApp(p => this.ViewModel.DownloadingUpdatePercentage = p);
 			NuGet.SemanticVersion currentVersion = updateManager.CurrentlyInstalledVersion();
 			if (result is null || result.Version == currentVersion)
 			{

--- a/src/MoneyMan.WPF/ViewModel/MainPageViewModel.cs
+++ b/src/MoneyMan.WPF/ViewModel/MainPageViewModel.cs
@@ -12,6 +12,7 @@ namespace MoneyMan.ViewModel
 		private bool updateAvailable;
 		private string version = ThisAssembly.AssemblyInformationalVersion;
 		private DocumentViewModel document = new DocumentViewModel();
+		private int? downloadingUpdatePercentage;
 
 		public DocumentViewModel Document
 		{
@@ -29,6 +30,12 @@ namespace MoneyMan.ViewModel
 		{
 			get => this.updateAvailable;
 			set => this.SetProperty(ref this.updateAvailable, value);
+		}
+
+		public int? DownloadingUpdatePercentage
+		{
+			get => this.downloadingUpdatePercentage;
+			set => this.SetProperty(ref this.downloadingUpdatePercentage, value);
 		}
 
 		public string Version


### PR DESCRIPTION
- [x] Offer the ARM64 app. We already build it, and it works. But we can't mix it into the github release assets, so we need to push to a new location (e.g. Amazon S3).
- [x] Offer delta update support, which may require downloading (all?) prior releases to the pipeline before using squirrel --releasify. We may want to do this in the release pipeline instead of the build one.
- [x] Introduce `release` and `prerelease` channels.

A huge dent in the opportunities brought up in #27.