### PR TITLE
Fix crash when deleting rows

### DIFF
--- a/src/Nerdbank.MoneyManagement/ViewModels/SortedObservableCollection`1.cs
+++ b/src/Nerdbank.MoneyManagement/ViewModels/SortedObservableCollection`1.cs
@@ -177,7 +177,17 @@ namespace Nerdbank.MoneyManagement.ViewModels
 		}
 
 		/// <inheritdoc/>
-		int IList.IndexOf(object? value) => this.IndexOf((T)value!);
+		int IList.IndexOf(object? value)
+		{
+			var index = this.IndexOf((T)value!);
+			return index < 0 ? -1 : index;
+		}
+
+		int IList<T>.IndexOf(T item)
+		{
+			var index = this.IndexOf((T)item!);
+			return index < 0 ? -1 : index;
+		}
 
 		/// <inheritdoc/>
 		public bool Contains(T item) => this.IndexOf(item) >= 0;

--- a/test/Nerdbank.MoneyManagement.Tests/ViewModels/SortedObservableCollectionTests.cs
+++ b/test/Nerdbank.MoneyManagement.Tests/ViewModels/SortedObservableCollectionTests.cs
@@ -236,6 +236,7 @@ public class SortedObservableCollectionTests : TestBase
 	[Fact]
 	public void IndexOf()
 	{
+		// The concrete public method returns the bitwise complement of the sorted location of where an item *would* be when not found.
 		Assert.Equal(~0, this.collection.IndexOf(3));
 		this.collection.Add(5);
 		this.collection.Add(10);
@@ -247,13 +248,27 @@ public class SortedObservableCollectionTests : TestBase
 	[Fact]
 	public void IndexOf_IList()
 	{
+		// This interface is documented as returning exactly -1 when items are not found.
 		IList collection = this.collection;
 		Assert.Equal(~0, collection.IndexOf(3));
 		this.collection.Add(5);
 		this.collection.Add(10);
-		Assert.Equal(~0, collection.IndexOf(15));
-		Assert.Equal(~1, collection.IndexOf(7));
-		Assert.Equal(~2, collection.IndexOf(3));
+		Assert.Equal(-1, collection.IndexOf(15));
+		Assert.Equal(-1, collection.IndexOf(7));
+		Assert.Equal(-1, collection.IndexOf(3));
+	}
+
+	[Fact]
+	public void IndexOf_IListOfT()
+	{
+		// This interface is documented as returning exactly -1 when items are not found.
+		IList<int> collection = this.collection;
+		Assert.Equal(~0, collection.IndexOf(3));
+		this.collection.Add(5);
+		this.collection.Add(10);
+		Assert.Equal(-1, collection.IndexOf(15));
+		Assert.Equal(-1, collection.IndexOf(7));
+		Assert.Equal(-1, collection.IndexOf(3));
 	}
 
 	[Fact]


### PR DESCRIPTION
WPF can't handle negative numbers other than -1 from `IList.IndexOf`.
